### PR TITLE
WIP: switch between installed versions

### DIFF
--- a/golang/install.bash
+++ b/golang/install.bash
@@ -41,8 +41,23 @@ set -u
 # Install go #
 ###################
 
+common_go_home="${HOME}/.local/opt/go-v${WEBI_VERSION}"
 new_go_home="${HOME}/.local/opt/go-v${WEBI_VERSION}"
 new_go="${HOME}/.local/opt/go-v${WEBI_VERSION}/bin/go"
+
+update_go_home() {
+    rm -rf "$common_go_home"
+    ln -s "$new_go_home" "$common_go_home"
+
+    # TODO get better output from pathman / output the path to add as return to webi bootstrap
+    webi_path_add "$common_go_home/bin"
+    webi_path_add "$HOME/go/bin"
+}
+
+if [ -x "$new_go_home/bin/go" ]; then
+  update_go_home
+  exit 0
+fi
 
 # Test for existing version
 set +e
@@ -96,9 +111,7 @@ popd 2>&1 >/dev/null
 #   Update PATH   #
 ###################
 
-# TODO get better output from pathman / output the path to add as return to webi bootstrap
-webi_path_add "$new_go_home/bin"
-webi_path_add "$HOME/go/bin"
+update_go_home
 
 echo "Installed 'go' (and go tools)"
 echo ""

--- a/node/install.bash
+++ b/node/install.bash
@@ -91,8 +91,22 @@ set -u
 #  Install node  #
 ##################
 
+common_node_home="${HOME}/.local/opt/node"
 new_node_home="${HOME}/.local/opt/node-v${WEBI_VERSION}"
 new_node="${HOME}/.local/opt/node-v${WEBI_VERSION}/bin/node"
+
+update_node_home() {
+    rm -rf "$common_node_home"
+    ln -s "$new_node_home" "$common_node_home"
+
+    # TODO get better output from pathman / output the path to add as return to webi bootstrap
+    webi_path_add "$common_node_home/bin"
+}
+
+if [ -x "$new_go_home/bin/go" ]; then
+  update_node_home
+  exit 0
+fi
 
 # Test for existing version
 set +e
@@ -140,8 +154,7 @@ popd 2>&1 >/dev/null
 #   Update PATH   #
 ###################
 
-# TODO get better output from pathman / output the path to add as return to webi bootstrap
-webi_path_add "$new_node_home/bin"
+update_node_home
 
 echo "Installed 'node' and 'npm'"
 echo ""

--- a/node/install.bash
+++ b/node/install.bash
@@ -103,7 +103,7 @@ update_node_home() {
     webi_path_add "$common_node_home/bin"
 }
 
-if [ -x "$new_go_home/bin/go" ]; then
+if [ -x "$new_node_home/bin/node" ]; then
   update_node_home
   exit 0
 fi


### PR DESCRIPTION
This behaves as expected:

```bash
webi node@12
webi node@14
```

This yields confusing results (I stay on node 14)

```bash
webi node@12
# a few days later
webi node@14
# a few days later
webi node@12
```

This also yields confusing results (I go back to node 12, because it's in my PATH)

```bash
webi node@12
# a few days later
webi node@14
# a few days later
rm -rf ~/.local/opt/node-v14*
```