### PR TITLE
hotfix for amd64 misclassification

### DIFF
--- a/pathman/releases.js
+++ b/pathman/releases.js
@@ -7,12 +7,6 @@ var baseurl = 'https://git.rootprojects.org';
 
 module.exports = function (request) {
   return github(request, owner, repo, baseurl).then(function (all) {
-    all.releases.forEach(function (rel) {
-      // TODO name uploads with arch, duh
-      if (!rel.arch) {
-        rel.arch = 'amd64';
-      }
-    });
     return all;
   });
 };


### PR DESCRIPTION
Originally `pathman` was only for `amd64`.

This remained true on Windows 10 and OS X, but changed for Linux. This fixes that.