### PR TITLE
whitespace bugfix for bash command

### DIFF
--- a/vps-utils/cap-net-bind.sh
+++ b/vps-utils/cap-net-bind.sh
@@ -5,7 +5,7 @@
     set -u
 
     my_bin="$1"
-    if [ -z "$(which $my_bin)"]; then
+    if [ -z "$(which $my_bin)" ]; then
         echo "'$my_bin' not found"
         exit 1
     fi


### PR DESCRIPTION
Fixes whitespace bug that caused syntax error.