### PR TITLE
correct Prettier cheat sheet about `--ignore`

### DIFF
--- a/prettier/README.md
+++ b/prettier/README.md
@@ -20,13 +20,13 @@ npm install -g prettier@latest
 Prettify all web files in a project, recursively:
 
 ```bash
-prettier --write '**/*{.md,.js,.html,.css}' --ignore ./dist
+prettier --write '**/*{.md,.js,.html,.css}'
 ```
 
 Tell Prettier which files to ignore every time
 
 ```bash
-echo "./dist" >> .prettierignore
+echo "dist/" >> .prettierignore
 ```
 
 Tell Prettier which settings to use - do NOT use `package.json` when it's not


### PR DESCRIPTION
Addressing issue #69

Closest flag to this is the --ignore-path option in the Prettier docs, but it's different (path to a list of ignored directories). Doesn't seem necessary to include here as it already looks for the ./.prettierignore file