### PR TITLE
Add comrak for Markdown to HTML

### DIFF
--- a/_npm/README.md
+++ b/_npm/README.md
@@ -9,6 +9,12 @@ Effortlessly install developer tools with easy-to-remember URLs.
 - without touching system files or permissions
 - without looking up docs
 
+## Install webi via npm:
+
+```bash
+npm install -g webi
+```
+
 ## Example: Installing node
 
 Mac & Linux:
@@ -24,6 +30,9 @@ curl.exe -fsSA "MS" https://webinstall.dev/node | powershell
 ```
 
 ## Example: Switching node versions
+
+Once `webi` is installed, you can then install commands or switch versions with
+webi itself:
 
 ```bash
 webi node@stable

--- a/_npm/package-lock.json
+++ b/_npm/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@root/webi",
+  "name": "webi",
   "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/_npm/package.json
+++ b/_npm/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@root/webi",
-  "version": "0.5.0",
+  "name": "webi",
+  "version": "0.5.1",
   "description": "Effortlessly install developer tools with easy-to-remember URLs",
   "main": "index.js",
   "homepage": "https://webinstall.dev",
@@ -8,7 +8,7 @@
     "scripts/"
   ],
   "scripts": {
-    "postinstall": "node scripts/webi.js",
+    "postinstall": "node scripts/install-webi.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -319,10 +319,10 @@ if [ -n "$(command -v pkg_get_current_version)" ]; then
 
     webi_link
 
+    _webi_enable_exec
     pushd "$WEBI_TMP" 2>&1 >/dev/null
         [ -n "$(command -v pkg_post_install)" ] && pkg_post_install || webi_post_install
     popd 2>&1 >/dev/null
-    _webi_enable_exec
 
     pushd "$WEBI_TMP" 2>&1 >/dev/null
         [ -n "$(command -v pkg_done_message)" ] && pkg_done_message || _webi_done_message

--- a/comrak/README.md
+++ b/comrak/README.md
@@ -1,0 +1,118 @@
+---
+title: Comrak
+homepage: https://github.com/kivikakk/comrak
+tagline: |
+  Comrak is a Rust port of github's cmark-gfm.
+---
+
+### Updating `comrak`
+
+`webi comrak@stable`
+
+Use the `@beta` tag for pre-releases.
+
+## Cheat Sheet
+
+> Comrak supports the five extensions to CommonMark defined in the GitHub
+> Flavored Markdown Spec: Tables, Task list items, Strikethrough, Autolinks, &
+> Disallowed Raw HTML
+
+```bash
+comrak --gfm index.md > index.html
+```
+
+Here you'll learn how to:
+
+- Convert Markdown to HTML
+- Set Reasonable Defaults
+- Safely Render _Untrusted_ HTML
+- Render _Trusted_ HTML with Scripts
+- Temporarily Ignore Defaults
+
+## How to Convert Markdown to HTML
+
+```bash
+comrak --gfm --header-ids '' README.md > README.html
+```
+
+## How to set Reasonable Defaults
+
+You can update `~/.config/comrak/config` to change Comrak from it's very strict
+defaults to always include your favorite options.
+
+Here's what I suggest:
+
+```bash
+echo "--gfm --header-ids ''" > ~/.config/comrak/config
+```
+
+See `comrak --help` for other options.
+
+## How to Render _Untrusted_ HTML
+
+Comrak does NOT have an option to allow arbitrary HTML while protecting against
+unsafe links, such as `<a href="javascript:...">`.
+
+Therefore, you **MUST enable CSP** for comrak-rendered site to disallow unsafe
+inline scripts. This can be done via a `<meta>` tag or HTTP headers.
+
+Example:
+
+```html
+<meta http-equiv="Content-Security-Policy" content="default-src *" />
+```
+
+Then, to sanitize `<script>` and `<iframe>` tags you must add `-e tagfilter`
+(which the `--gfm` option also enables).
+
+```bash
+comrak --unsafe --gfm --header-ids '' README.md
+```
+
+## How to Render HTML & Scripts
+
+The `--unsafe` option
+[may not work as expected](https://github.com/kivikakk/comrak/issues/160) with
+`--gfm`, as it is still somewhat neutered by `-e tagfilter`.
+
+If you want Github-Flavored Markdown with trusted scripts, you'll need to enable
+its extensions by hand:
+
+```bash
+echo "
+# WARNING: allows <script>, <iframe>
+# and <a href=javascript:alert('')>
+--unsafe
+
+# same as --gfm, but without -e tagfilter,
+# meaning ALL html tags are allowed
+-e strikethrough
+-e table
+-e autolink
+-e tasklist
+--github-pre-lang
+
+# linkable headers (w/ empty prefix)
+--header-ids ''
+
+# additional extensions
+-e superscript
+-e footnotes
+-e description-lists
+
+" > ~/.config/comrak/allow-scripts
+```
+
+```bash
+comrak --config ~/.config/comrak/allow-scripts README.md
+```
+
+## How to Ignore Defaults
+
+You can disable all options with `--config-file none`.
+
+Example:
+
+```bash
+comrak --config-file none -e table README.md
+```

--- a/comrak/install.ps1
+++ b/comrak/install.ps1
@@ -1,0 +1,41 @@
+#!/usr/bin/env pwsh
+
+$VERNAME = "$Env:PKG_NAME-v$Env:WEBI_VERSION.exe"
+$EXENAME = "$Env:PKG_NAME.exe"
+# Fetch archive
+IF (!(Test-Path -Path "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"))
+{
+    # TODO: arch detection
+    echo "Downloading $Env:PKG_NAME from $Env:WEBI_PKG_URL to $Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+    & curl.exe -A "$Env:WEBI_UA" -fsSL "$Env:WEBI_PKG_URL" -o "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part"
+    & move "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE.part" "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE"
+}
+
+IF (!(Test-Path -Path "$Env:USERPROFILE\.local\opt\$Env:PKG_NAME-v$Env:WEBI_VERSION\bin\$VERNAME"))
+{
+    echo "Installing $Env:PKG_NAME"
+    # TODO: temp directory
+
+    # Enter tmp
+    pushd .local\tmp
+
+        # Remove any leftover tmp cruft
+        Remove-Item -Path "$Env:PKG_NAME-v*" -Recurse -ErrorAction Ignore
+
+        # Move single binary into root of temporary folder
+        & move "$Env:USERPROFILE\Downloads\$Env:WEBI_PKG_FILE" "$VERNAME"
+        & dir
+
+        # Settle unpacked archive into place
+        echo "New Name: $VERNAME"
+        echo "New Location: $Env:USERPROFILE\.local\opt\$Env:PKG_NAME-v$Env:WEBI_VERSION\bin\$VERNAME"
+        New-Item "$Env:USERPROFILE\.local\opt\$Env:PKG_NAME-v$Env:WEBI_VERSION\bin" -ItemType Directory
+        Move-Item -Path "$VERNAME" -Destination "$Env:USERPROFILE\.local\opt\$Env:PKG_NAME-v$Env:WEBI_VERSION\bin"
+
+    # Exit tmp
+    popd
+}
+
+echo "Copying into '$Env:USERPROFILE\.local\bin\$EXENAME' from '$Env:USERPROFILE\.local\opt\$Env:PKG_NAME-v$Env:WEBI_VERSION\bin\$VERNAME'"
+Remove-Item -Path "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse -ErrorAction Ignore
+Copy-Item -Path "$Env:USERPROFILE\.local\opt\$Env:PKG_NAME-v$Env:WEBI_VERSION\bin\$VERNAME" -Destination "$Env:USERPROFILE\.local\bin\$EXENAME" -Recurse

--- a/comrak/install.sh
+++ b/comrak/install.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+{
+    set -e
+    set -u
+
+    ##################
+    # Install comrak #
+    ##################
+
+    WEBI_SINGLE=true
+
+    pkg_get_current_version() {
+      # 'comrak --version' has output in this format:
+      #       comrak 0.8.1
+      # This trims it down to just the version number:
+      #       0.8.1
+      echo $(comrak --version 2>/dev/null | head -n 1 | cut -d' ' -f 2)
+    }
+
+    pkg_install() {
+        # ~/.local/bin
+        mkdir -p "$pkg_src_bin"
+
+        # mv ./comrak* ~/.local/opt/comrak-v0.8.1/bin/comrak
+        mv ./comrak* "$pkg_src_cmd"
+
+        # chmod a+x ~/.local/opt/comrak-v0.8.1/bin/comrak
+        chmod a+x "$pkg_src_cmd"
+    }
+
+    pkg_post_install() {
+        # create the xdg directories (i.e. ~/.config/comrak)
+        "$pkg_src_cmd" --version > /dev/null
+    }
+}

--- a/comrak/releases.js
+++ b/comrak/releases.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var github = require('../_common/github.js');
+var owner = 'kivikakk';
+var repo = 'comrak';
+
+module.exports = function (request) {
+  return github(request, owner, repo).then(function (all) {
+    return all;
+  });
+};
+
+if (module === require.main) {
+  module.exports(require('@root/request')).then(function (all) {
+    all = require('../_webi/normalize.js')(all);
+    all.releases = all.releases.slice(0, 10);
+    //console.info(JSON.stringify(all));
+    console.info(JSON.stringify(all, null, 2));
+  });
+}


### PR DESCRIPTION
Re: #75 

Had to dig a bit into a lot of nuance detail in regards to both safely escaped HTML + CSP and raw unsafe HTML + scripts.

Also accidentally included the `_npm` updates. Just as well to merge those now too.

## Preview

Live at https://beta.webinstall.dev/comrak

```bash
export WEBI_HOST=https://beta.webinstall.dev
curl -fsS https://webinstall.dev/comrak | bash
```

## TODO

I still want to add this to the homepage too.