### PR TITLE
remove xattr com.apple.quarantine before trying spctl

### DIFF
--- a/_webi/template.sh
+++ b/_webi/template.sh
@@ -239,6 +239,12 @@ webi_post_install() {
 }
 
 _webi_enable_exec() {
+    if [ -n "$(command -v spctl)" ] && [ -n "$(command -v xattr)" ] ; then
+        xattr -r -d com.apple.quarantine "$pkg_src"
+        return 0
+    fi
+    # TODO need to test that the above actually worked
+    # (and proceed to this below if it did not)
     if [ -n "$(command -v spctl)" ]; then
         echo "Checking permission to execute '$pkg_cmd_name' on macOS 11+"
         set +e


### PR DESCRIPTION
`spctl` requires a `sudo` / Admin prompt, which will ALWAYS trigger on High Sierra and sometimes trigger on Catalina.

By trying xattr first, we can avoid the admin prompt.

Without being an apple guru it's difficult to tell if this will work as expected, but I've tested it as best I can.

## Update

Tested with a fresh Catalina VM. All is well there, so I must assume all is well, period.