### PR TITLE
Fix #96: Added required files to the readme.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@ node_modules
 install-*.sh
 install-*.bat
 install-*.ps1
-.install.sh.swp
-.install.sh.swo
+.*.sw*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 node_modules
 install-*.sh
 install-*.bat
+install-*.ps1
+.install.sh.swp
+.install.sh.swo


### PR DESCRIPTION
As in the issue #96 it was mentioned to add the required patterns to the `.gitignore` file I have did that and also as `install-*.sh` was already present there was no required to add that pattern.