### PR TITLE
rg: tweak the wording in the ripgrep description

### DIFF
--- a/rg/README.md
+++ b/rg/README.md
@@ -16,9 +16,9 @@ Use the `@beta` tag for pre-releases.
 ## Cheat Sheet
 
 > Ripgrep (`rg`) is smart. It's like grep if grep were built for code. It
-> respects `.gitignore` and `.ignore`, has all of the sensible options you want
-> (colors, numbers, etc) turned on by default, is written in Rust, and simply
-> outperforms grep in every imaginable way.
+> respects `.gitignore` and `.ignore`, has all of the sensible options you
+> want (colors, numbers, etc) turned on by default, is written in Rust, and
+> typically outperforms grep in many use cases.
 
 ```bash
 rg <search-term> # searches recursively, ignoring .git, node_modules, etc

--- a/rg/README.md
+++ b/rg/README.md
@@ -18,7 +18,7 @@ Use the `@beta` tag for pre-releases.
 > Ripgrep (`rg`) is smart. It's like grep if grep were built for code. It
 > respects `.gitignore` and `.ignore`, has all of the sensible options you want
 > (colors, numbers, etc) turned on by default, is written in Rust, and simply
-> outperforms grep in every imaginable way. R.I.P. grep.
+> outperforms grep in every imaginable way.
 
 ```bash
 rg <search-term> # searches recursively, ignoring .git, node_modules, etc


### PR DESCRIPTION
The commit messages provide a tiny bit more detail, but basically:

1. The "rip" in "ripgrep" means "to rip through text" and not "kill grep" or "grep is dead."
2. Dial back some embellishment about ripgrep's performance.

Disclaimer: I'm the author of ripgrep.

Thanks!